### PR TITLE
Add 'spread' stanza's to .nomad to align with deployed apps

### DIFF
--- a/dp-hello-world-api/dp-hello-world-api.nomad
+++ b/dp-hello-world-api/dp-hello-world-api.nomad
@@ -14,6 +14,17 @@ job "dp-hello-world-api" {
   group "web" {
     count = "{{WEB_TASK_COUNT}}"
 
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+
     constraint {
       attribute = "${node.class}"
       value     = "web"
@@ -77,6 +88,17 @@ job "dp-hello-world-api" {
 
   group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
+
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
 
     constraint {
       attribute = "${node.class}"

--- a/dp-hello-world-controller/dp-hello-world-controller.nomad
+++ b/dp-hello-world-controller/dp-hello-world-controller.nomad
@@ -14,6 +14,17 @@ job "dp-hello-world-controller" {
   group "web" {
     count = "{{WEB_TASK_COUNT}}"
 
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+
     constraint {
       attribute = "${node.class}"
       value     = "web"
@@ -77,6 +88,17 @@ job "dp-hello-world-controller" {
 
   group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
+
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
 
     constraint {
       attribute = "${node.class}"

--- a/dp-hello-world-event/dp-hello-world-event.nomad
+++ b/dp-hello-world-event/dp-hello-world-event.nomad
@@ -14,6 +14,17 @@ job "dp-hello-world-event" {
   group "web" {
     count = "{{WEB_TASK_COUNT}}"
 
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+
     constraint {
       attribute = "${node.class}"
       value     = "web"
@@ -77,6 +88,17 @@ job "dp-hello-world-event" {
 
   group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
+
+    spread {
+      attribute = "${node.unique.id}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
+    spread {
+      attribute = "${attr.platform.aws.placement.availability-zone}"
+      weight    = 100
+      # with `target` omitted, Nomad will spread allocations evenly across all values of the attribute.
+    }
 
     constraint {
       attribute = "${node.class}"


### PR DESCRIPTION
### What

As per title

### How to review

Compare to live app, for example dp-cantabular-xlsx-exporter's .nomad file

### Who can review

Anyone
